### PR TITLE
wrap import of ravello_sdk with try/except; fix copyright year

### DIFF
--- a/auth_local.py
+++ b/auth_local.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014 Ravshello Authors
+# Copyright 2015 Ravshello Authors
 # License: Apache License 2.0 (see LICENSE or http://apache.org/licenses/LICENSE-2.0.html)
 
 from __future__ import print_function

--- a/auth_ravello.py
+++ b/auth_ravello.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014 Ravshello Authors
+# Copyright 2015 Ravshello Authors
 # License: Apache License 2.0 (see LICENSE or http://apache.org/licenses/LICENSE-2.0.html)
 
 from __future__ import print_function
@@ -9,7 +9,12 @@ from sys import exit as sysexit
 
 # Custom modules
 import rsaw_ascii
-from ravello_sdk import *
+try:
+    from ravello_sdk import *
+except:
+    print("Missing a required python module (ravello_sdk)\n"
+          "Get it from https://github.com/ryran/python-sdk\n")
+    raise
 from local_config import RavelloLogin 
 
 

--- a/ravshello.py
+++ b/ravshello.py
@@ -17,7 +17,7 @@
 #-------------------------------------------------------------------------------
 
 from __future__ import print_function
-ravshelloVersion = "ravshello v1.2.0 last mod 2015/01/03"
+ravshelloVersion = "ravshello v1.2.1 last mod 2015/01/03"
 
 # Modules from standard library
 import argparse

--- a/rsaw_ascii.py
+++ b/rsaw_ascii.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014 Ravshello Authors
+# Copyright 2015 Ravshello Authors
 # License: Apache License 2.0 (see LICENSE or http://apache.org/licenses/LICENSE-2.0.html)
 
 from __future__ import print_function

--- a/user_interface.py
+++ b/user_interface.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014 Ravshello Authors
+# Copyright 2015 Ravshello Authors
 # License: Apache License 2.0 (see LICENSE or http://apache.org/licenses/LICENSE-2.0.html)
 
 from __future__ import print_function
@@ -23,7 +23,7 @@ try:
     from configshell import shell as cfshell, ConfigNode
 except:
     print("Missing a required python module (configshell)\n"
-          "On RHEL/Fedora, install it with:\n"
+          "On RHEL/Fedora, install it with command:\n"
           "                        yum install python-configshell\n")
     raise
 # Remove configshell commands that we don't need or want
@@ -33,7 +33,12 @@ del ConfigNode.ui_complete_bookmarks
 
 # Custom ravshello modules
 import rsaw_ascii
-from ravello_sdk import *
+try:
+    from ravello_sdk import *
+except:
+    print("Missing a required python module (ravello_sdk)\n"
+          "Get it from https://github.com/ryran/python-sdk\n")
+    raise
 from local_config import RavshelloUI 
 
 


### PR DESCRIPTION
Changes:

* Since we don't ship `ravello_sdk` and it's not in the standard library, it would be a good idea to make it clear where to get. Especially because we use some features that aren't in the upstream ravello_sdk.

* Accidentally set copyright date to 2014 in some of the files last night before the initial commit. Fixed.