### PR TITLE
check ravello_sdk.is_rsaw_sdk() on import and throw error if fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+ravello_sdk.py
 *.pyc
 *~
 *.egg-info

--- a/auth_ravello.py
+++ b/auth_ravello.py
@@ -10,10 +10,11 @@ from getpass import getpass
 # Custom modules
 import rsaw_ascii
 try:
-    from ravello_sdk import *
+    import ravello_sdk
+    ravello_sdk.is_rsaw_sdk()
 except:
-    print("Missing a required python module (ravello_sdk)\n"
-          "Get it from https://github.com/ryran/python-sdk\n")
+    print("Missing proper version of required python module (rsaw's ravello_sdk)\n"
+          "Get it from https://github.com/ryran/python-sdk/tree/experimental\n")
     raise
 from local_config import RavelloLogin 
 
@@ -55,7 +56,7 @@ def login(opt):
     c = rsaw_ascii.AsciiColors(ravshOpt.enableAsciiColors)
     
     # Create client object
-    ravClient = RavelloClient()
+    ravClient = ravello_sdk.RavelloClient()
     
     verbose("\nConnecting to Ravello . . .")
     

--- a/ravshello.py
+++ b/ravshello.py
@@ -16,17 +16,17 @@
 # limitations under the License.
 #-------------------------------------------------------------------------------
 
-from __future__ import print_function
-
-ravshelloVersion = "ravshello v1.2.5 last mod 2015/01/06"
-
 # Modules from standard library
+from __future__ import print_function
 import argparse
 import os
 import sys
 
 # Custom ravshello modules
 import rsaw_ascii, auth_local, auth_ravello, user_interface
+
+# Set version here for now bleh
+ravshelloVersion = "ravshello v1.2.6 last mod 2015/01/07"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Moving forward, we need a way to confirm that we're using the right sdk. Added that to the experimental branch of the sdk and this pull request makes ravshello take advantage of it.