### PR TITLE
/billing this_months_summary() & select_months_summary() output to pager

### DIFF
--- a/_version.py
+++ b/_version.py
@@ -2,5 +2,5 @@
 # Copyright 2015 Ravshello Authors
 # License: Apache License 2.0 (see LICENSE or http://apache.org/licenses/LICENSE-2.0.html)
 
-__version__ = '1.3.10-dev'
+__version__ = '1.3.11-dev'
 __date__    = '2015/01/30'


### PR DESCRIPTION
CHANGELOG:

- #37 : All billing functions go to pager by default now (except export_month_to_csv which goes to term)
- All billing functions can be dumped to files.
- "Fixed" docstrings for all `ui_command_` methods ... to be compliant with what configshell expects in order to properly generate help pages. 
- Changed `sortBy` values from `rav` & `kerb` to `user` & `nick`.