### PR TITLE
Support auto-creating apps in cost buckets #155

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,22 +21,33 @@
 
 
 ######
+## Optionally specify a default cost bucket (by name or numeric ID) in which to
+## place all new apps created by ravshello. You will need execute permission on
+## the cost bucket in order to associate an application with it.
+
+#appCostBucket: myCostBucketNameOrId
+
+
+######
 ## Optionally declare MULTIPLE sets of Ravello credentials and map them to
 ## profile names. The names are arbitrary and can be selected by use of
 ## the -u or --user cmdline option. Notes:
 ##  - *ravelloUser* is required.
 ##  - *ravelloPass* is not required. (Will be prompted for pass.)
 ##  - *nickname* is not required.
+##  - *appCostBucket* is not required.
 ##  - *defaultProfile* is not required.
 
 #userProfiles:
 #    bob:
 #        ravelloUser: bob@example.com
 #        ravelloPass: xxxxx
+#        appCostBucket: QA
 #    ana:
 #        ravelloUser: anabanana@example.com
 #        ravelloPass: xxxxx
 #        nickname: ana
+#        appCostBucket: DEV
 #    wow@example:
 #        ravelloUser: wow@example.com
 #    defaultProfile: ana

--- a/modules/auth_ravello.py
+++ b/modules/auth_ravello.py
@@ -65,6 +65,8 @@ def login():
     cfgPass = cfg.cfgFile.get('ravelloPass', None)
     profiles = cfg.cfgFile.get('userProfiles', {})
     user = passwd = userFrom = profile = None
+    # Set default cb
+    cfg.appCostBucket = cfg.cfgFile.get('appCostBucket', None)
     # If necessary, get Ravello *username* from configfile or prompt
     try:
         profile = profiles[rOpt.ravelloUser]
@@ -80,20 +82,32 @@ def login():
         else:
             try:
                 user = profiles[profiles['defaultProfile']]['ravelloUser']
+                userFrom = 'defaultProfile'
             except:
                 user = get_username(c.CYAN("  Enter Ravello username: "))
+    # Set per-user cb
+    if userFrom == 'profile':
+        try:
+            cfg.appCostBucket = profile['appCostBucket']
+        except:
+            pass
+    elif userFrom == 'defaultProfile':
+        try:
+            cfg.appCostBucket = profiles[profiles['defaultProfile']]['appCostBucket']
+        except:
+            pass
     # If necessary, get Ravello *password* from configfile or prompt
     if rOpt.ravelloPass:
         passwd = rOpt.ravelloPass
     elif userFrom == 'profile':
         pass
-    elif userFrom == 'cfg':
-        passwd = cfgPass
-    else:
+    elif userFrom == 'defaultProfile':
         try:
             passwd = profiles[profiles['defaultProfile']]['ravelloPass']
         except:
             pass
+    elif userFrom == 'cfg':
+        passwd = cfgPass
     if not passwd:
         passwd = get_passphrase(c.CYAN("  Enter Ravello passphrase: "))
     rOpt.ravelloUser = user

--- a/modules/cfg.py
+++ b/modules/cfg.py
@@ -6,8 +6,8 @@
 prog = 'ravshello'
 
 # Version info
-__version__ = '1.27.0'
-__date__    = '2017/04/27'
+__version__ = '1.28.0'
+__date__    = '2017/07/15'
 version = "{} v{} last mod {}".format(prog, __version__, __date__)
 
 # Defaults
@@ -33,6 +33,9 @@ opts = None
 
 # This will hold the local username
 user = None
+
+# This will hold the default app cost bucket
+appCostBucket = None
 
 # This will hold the RavelloClient object
 rClient = None


### PR DESCRIPTION
- Add support for appCostBucket config-file directive. Works in global
  context or in per-user profiles.
- Add internal App.move_to_cost_bucket(); no interactive command yet.
- Conditionally call above (if config-file specified appCostBucket) at
  the end of Applications.new() -- after app creation, before publish.

See comments in #155 for full details and example usage.